### PR TITLE
[issue-6] pravega as source dependency and update to 0.3.0-SNAPSHOT

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "pravega"]
+	path = pravega
+	url = https://github.com/pravega/pravega.git
+	branch = master

--- a/README.md
+++ b/README.md
@@ -4,30 +4,37 @@ Apache Hadoop connectors for Pravega.
 Description
 -----------
 
-Implementation of PravegaInputFormat (with wordcount examples). It leverages Pravega batch client to read all existing events in parallel
-
+Implementation of a Hadoop input format for Pravega (with wordcount examples). It leverages Pravega batch client to read all existing events in parallel.
 
 Build
 -------
+The build script handles Pravega as a _source dependency_, meaning that the connector is linked to a specific commit of Pravega (as opposed to a specific release version) in order to faciliate co-development.  This is accomplished with a combination of a _git submodule_ and the use of Gradle's _composite build_ feature. 
+
+### Cloning the repository
+When cloning the connector repository, be sure to instruct git to recursively checkout submodules, e.g.:
+```
+git clone --recurse-submodules https://github.com/pravega/hadoop-connectors.git
+```
+
+To update an existing repository:
+```
+git submodule update --init --recursive
+```
 
 ### Building Pravega
+Pravega is built automatically by the connector build script.
 
-Install the Pravega client libraries to your local Maven repository:
+### Building Hadoop Connector
+Build the connector:
 ```
-$ git clone https://github.com/pravega/pravega.git
-$./gradlew install
-```
-
-### Building PravegaInputFormat
-```
-gradle build (w/o dependencies)
-gradle shadowJar (w/ dependencies)
+./gradlew build (w/o dependencies)
+./gradlew shadowJar (w/ dependencies)
 ```
 
 Test
 -------
 ```
-gradle test
+./gradlew test
 ```
 
 Usage
@@ -51,11 +58,11 @@ Run Examples
 ```
 Hadoop (verified with Hadoop 2.8.1 on Ubuntu 16.04)
 
-HADOOP_CLASSPATH=build/libs/hadoop-connectors-0.2.0-SNAPSHOT-all.jar HADOOP_USER_CLASSPATH_FIRST=true hadoop jar build/libs/hadoop-connectors-0.2.0-SNAPSHOT-all.jar io.pravega.examples.hadoop.WordCount tcp://192.168.0.200:9090 myScope myStream /tmp/wordcount_output_new_dir
+HADOOP_CLASSPATH=build/libs/hadoop-connectors-0.3.0-SNAPSHOT-all.jar HADOOP_USER_CLASSPATH_FIRST=true hadoop jar build/libs/hadoop-connectors-0.3.0-SNAPSHOT-all.jar io.pravega.examples.hadoop.WordCount tcp://192.168.0.200:9090 myScope myStream /tmp/wordcount_output_new_dir
 ```
 
 ```
 Spark (verified with Spark 2.2.0 on Ubuntu 16.04)
 
-spark-submit --conf spark.driver.userClassPathFirst=true --class io.pravega.examples.spark.WordCount build/libs/hadoop-connectors-0.2.0-SNAPSHOT-all.jar tcp://192.168.0.200:9090 myScope myStream
+spark-submit --conf spark.driver.userClassPathFirst=true --class io.pravega.examples.spark.WordCount build/libs/hadoop-connectors-0.3.0-SNAPSHOT-all.jar tcp://192.168.0.200:9090 myScope myStream
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,5 +11,5 @@ scalaVersion=2.11.8
 sparkVersion=2.2.0
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.2.0-SNAPSHOT
-pravegaVersion=0.2.0-SNAPSHOT
+connectorVersion=0.3.0-SNAPSHOT
+pravegaVersion=0.3.0-SNAPSHOT

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,3 +9,24 @@
  */
 
 rootProject.name = 'hadoop-connectors'
+
+includeBuild('pravega') {
+    if (pravegaVersion.endsWith("-SNAPSHOT")) {
+        dependencySubstitution {
+            substitute module('io.pravega:pravega-client') with project(':client')
+            substitute module('io.pravega:pravega-common') with project(':common')
+            substitute module('io.pravega:pravega-controller') with project(':controller')
+            substitute module('io.pravega:pravega-segmentstore') with project(':segmentstore')
+            substitute module('io.pravega:pravega-segmentstore-contracts') with project(':segmentstore:contracts')
+            substitute module('io.pravega:pravega-segmentstore-server') with project(':segmentstore:server')
+            substitute module('io.pravega:pravega-segmentstore-server-host') with project(':segmentstore:server:host')
+            substitute module('io.pravega:pravega-segmentstore-storage') with project(':segmentstore:storage')
+            substitute module('io.pravega:pravega-segmentstore-storage-impl') with project(':segmentstore:storage:impl')
+            substitute module('io.pravega:pravega-shared') with project(':shared')
+            substitute module('io.pravega:pravega-shared-controller-api') with project(':shared:controller-api')
+            substitute module('io.pravega:pravega-shared-metrics') with project(':shared:metrics')
+            substitute module('io.pravega:pravega-shared-protocol') with project(':shared:protocol')
+            substitute module('io.pravega:pravega-standalone') with project(':standalone')
+        }
+    }
+}

--- a/src/main/java/io/pravega/connectors/hadoop/PravegaInputFormat.java
+++ b/src/main/java/io/pravega/connectors/hadoop/PravegaInputFormat.java
@@ -74,7 +74,7 @@ public class PravegaInputFormat<V> extends InputFormat<EventKey, V> {
             for (Iterator<SegmentInfo> iter = batchClient.listSegments(new StreamImpl(scopeName, streamName)); iter.hasNext(); ) {
                 SegmentInfo segInfo = iter.next();
                 Segment segment = segInfo.getSegment();
-                PravegaInputSplit split = new PravegaInputSplit(segment, 0, segInfo.getLength());
+                PravegaInputSplit split = new PravegaInputSplit(segment, segInfo.getStartingOffset(), segInfo.getWriteOffset());
                 splits.add(split);
             }
         }

--- a/src/main/java/io/pravega/connectors/hadoop/PravegaInputRecordReader.java
+++ b/src/main/java/io/pravega/connectors/hadoop/PravegaInputRecordReader.java
@@ -68,7 +68,7 @@ public class PravegaInputRecordReader<V> extends RecordReader<EventKey, V> {
             log.error("Exception when creating deserializer: {}", e);
             throw new IOException("Unable to create the event deserializer (" + deserializerClassName + ")", e);
         }
-        iterator = batchClient.readSegment(this.split.getSegment(), deserializer);
+        iterator = batchClient.readSegment(this.split.getSegment(), deserializer, this.split.getStartOffset(), this.split.getEndOffset());
     }
 
     /**

--- a/src/test/java/io/pravega/connectors/hadoop/PravegaInputFormatTest.java
+++ b/src/test/java/io/pravega/connectors/hadoop/PravegaInputFormatTest.java
@@ -65,12 +65,12 @@ public class PravegaInputFormatTest {
         PravegaInputFormat<Integer> inputFormat = new PravegaInputFormat<>();
         List<InputSplit> splits = inputFormat.getSplits(job);
         Assert.assertEquals(NUM_SEGMENTS, splits.size());
-        int totalEndOffset = 0;
+        int totalLength = 0;
         for (int i = 0; i < splits.size(); i++) {
             PravegaInputSplit p = (PravegaInputSplit) (splits.get(i));
             Assert.assertEquals(i, p.getSegment().getSegmentNumber());
-            totalEndOffset += p.getLength();
+            totalLength += p.getLength();
         }
-        Assert.assertEquals(NUM_EVENTS * 12, totalEndOffset);
+        Assert.assertEquals(NUM_EVENTS * 12, totalLength);
     }
 }

--- a/src/test/java/io/pravega/connectors/hadoop/PravegaInputFormatTest.java
+++ b/src/test/java/io/pravega/connectors/hadoop/PravegaInputFormatTest.java
@@ -65,16 +65,12 @@ public class PravegaInputFormatTest {
         PravegaInputFormat<Integer> inputFormat = new PravegaInputFormat<>();
         List<InputSplit> splits = inputFormat.getSplits(job);
         Assert.assertEquals(NUM_SEGMENTS, splits.size());
-        int totalLen, totalEndOffset;
-        totalLen = totalEndOffset = 0;
+        int totalEndOffset = 0;
         for (int i = 0; i < splits.size(); i++) {
             PravegaInputSplit p = (PravegaInputSplit) (splits.get(i));
             Assert.assertEquals(i, p.getSegment().getSegmentNumber());
-            Assert.assertEquals(0, p.getStartOffset());
-            totalLen += p.getEndOffset();
             totalEndOffset += p.getLength();
         }
-        Assert.assertEquals(NUM_EVENTS * 12, totalLen);
         Assert.assertEquals(NUM_EVENTS * 12, totalEndOffset);
     }
 }


### PR DESCRIPTION
**Change log description**
- composite build incorporating Pravega (master)

**Purpose of the change**
Satisfy hadoop-connector build dependency on Pravega as a source dependency.   Closes #88.

**What the code does**
- update Pravega to master (0.3.0-SNAPSHOT)
- update connection version to 0.3.0-SNAPSHOT
- update connector code to use latest Pravega API (segment truncation)
- add Pravega submodule
- include Pravega in composite build

**How to verify it**
