### PR TITLE
Use new client API getStreamInfo to fetch trail stream cut

### DIFF
--- a/src/main/java/io/pravega/connectors/hadoop/PravegaInputFormat.java
+++ b/src/main/java/io/pravega/connectors/hadoop/PravegaInputFormat.java
@@ -18,8 +18,8 @@ import com.google.gson.reflect.TypeToken;
 
 import io.pravega.client.ClientFactory;
 import io.pravega.client.batch.BatchClient;
-import io.pravega.client.batch.StreamSegmentsIterator;
 import io.pravega.client.batch.SegmentRange;
+import io.pravega.client.batch.StreamInfo;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamCut;
@@ -139,8 +139,8 @@ public class PravegaInputFormat<V> extends InputFormat<EventKey, V> {
     @VisibleForTesting
     public static String fetchPositionsJson(ClientFactory clientFactory, String scopeName, String streamName) throws IOException {
         BatchClient batchClient = clientFactory.createBatchClient();
-        StreamSegmentsIterator ssIter = batchClient.getSegments(Stream.of(scopeName, streamName), null, null);
-        StreamCut endStreamCut = ssIter.getEndStreamCut();
+        StreamInfo streamInfo = batchClient.getStreamInfo(Stream.of(scopeName, streamName)).join();
+        StreamCut endStreamCut = streamInfo.getTailStreamCut();
 
         Gson gson = new GsonBuilder()
             .enableComplexMapKeySerialization().create();

--- a/src/test/java/io/pravega/connectors/hadoop/PravegaInputFormatTest.java
+++ b/src/test/java/io/pravega/connectors/hadoop/PravegaInputFormatTest.java
@@ -11,6 +11,7 @@
 package io.pravega.connectors.hadoop;
 
 import io.pravega.client.batch.SegmentRange;
+import io.pravega.client.batch.StreamInfo;
 import io.pravega.client.batch.StreamSegmentsIterator;
 import io.pravega.client.batch.impl.SegmentRangeImpl;
 import io.pravega.client.batch.BatchClient;
@@ -29,6 +30,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -120,15 +122,21 @@ public class PravegaInputFormatTest {
         StreamSegmentsIterator mockStreamSegmentsIterator = mockStreamSegmentsIterator();
         Mockito.doReturn(mockStreamSegmentsIterator).when(mockBatchClient)
             .getSegments(anyObject(), anyObject(), anyObject());
+
+        CompletableFuture<StreamInfo> future = mock(CompletableFuture.class);
+        Mockito.doReturn(future).when(mockBatchClient).getStreamInfo(anyObject());
+
+        Stream s = new StreamImpl(TEST_SCOPE, TEST_STREAM);
+        StreamCutImpl sc = new StreamCutImpl(s, genPositions(10));
+        StreamInfo si = new StreamInfo(TEST_SCOPE, TEST_STREAM, sc, null);
+        Mockito.doReturn(si).when(future).join();
+
         return mockBatchClient;
     }
 
     private StreamSegmentsIterator mockStreamSegmentsIterator() {
         StreamSegmentsIterator mockStreamSegmentsIterator = mock(StreamSegmentsIterator.class);
         Mockito.doReturn(mockIterator()).when(mockStreamSegmentsIterator).getIterator();
-        Stream s = new StreamImpl(TEST_SCOPE, TEST_STREAM);
-        StreamCutImpl sc = new StreamCutImpl(s, genPositions(10));
-        Mockito.doReturn(sc).when(mockStreamSegmentsIterator).getEndStreamCut();
         return mockStreamSegmentsIterator;
     }
 

--- a/src/test/java/io/pravega/connectors/hadoop/utils/SetupUtils.java
+++ b/src/test/java/io/pravega/connectors/hadoop/utils/SetupUtils.java
@@ -73,6 +73,11 @@ public final class SetupUtils {
                 .isInProcSegmentStore(true)
                 .segmentStoreCount(1)
                 .containerCount(4)
+                // to match code change https://github.com/pravega/pravega/pull/2476
+                .keyFile("")
+                .certFile("")
+                .userName("")
+                .passwd("")
                 .build();
         this.inProcPravegaCluster.setControllerPorts(new int[]{controllerPort});
         this.inProcPravegaCluster.setSegmentStorePorts(new int[]{hostPort});


### PR DESCRIPTION
1. Use new client API getStreamInfo to fetch trail stream cut: https://github.com/pravega/pravega/pull/2454
2. Update test case accordingly
3. Add a few properties when setting up InProcPravegaCluster due to code change in https://github.com/pravega/pravega/pull/2476