### PR TITLE
[Issue 5] Publishing snapshot artifacts to JCenter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,29 @@
 language: java
+# the secure configurations in env: section is for BINTRAY_USER=<USER> and BINTRAY_KEY=<KEY> properties
+# which will be used for publishing artifacts to snapshot repository
 env:
   global:
   - GRADLE_OPTS="-Xms128m"
+  - secure: "HOWQF8zJrWYftBCsu/lnmG1gUN7jKu3dEMX7kc76jUugOMUbjW2BtQguG7cuI4NCz3XLBeYa9ZQMg1snvkWJcpKH/vpTLh7Mf6eV2h1/ocfCnFw/iQw1Y/Tsgr3jyr/usdGiClpHrzV/OC6p/n0shJmawfK40rSn1P3xiRdYOLHDd/vBkwxCbcS6mOOlLrKG5lXJ2GOGBWGWmXhbBCCy6XWJzF2+CFf02ieL6SvkxNwIlKrif8cYSzV+lAoxuoVPjK9qMbB3r/BD6+8vGjIAX4MgvWRGkok/tfuCBE+PQ1mJIJBKzq3T1Hy/0czWClNbTAAZKdSTErR4REdViZrddddr39olzn7Y7GYCcG/cnpfGnhmeQQ/9ddvH3do6Tb3rh/nxs2PeFuofDwoWLlwke6oed/yhI9tEZzBGdVW6y6HCcfYfvaliaSIB24SDBA8I2K/m2oay8f2gbDyVeBRK6pCEDCklbPGPBjVVfhqosgbFcZfCYO4WVGh3c1j+siT1yHNxsiVSYT6riIzA5D10o/8o+b/ex2AS6lmtQR2L9rpp+zzm7u1scvsXu6dUN/fPZqBZb3/kY8kh7xkoNCc3bYXOy3I76xu756FpR6VJkU1UkRDjT9cepza1A3YDvyAgEClseTFBKE+RSiBh9v7PVcW4oItJ+fRRvnakhroYByM="
+  - secure: "VH9F5YUSBh16A3gmTq/vE5Qt/yl+p8+TwrOIeELF7YvYS6915+Ju0BiLwq6EvJ2eZf3OZi5bdmXgdiuUHeyYtHCv4LK/RhClOeF0NtqlltXPUPKcoA+urgsT+UKQ7uSFgMaHhG+jDDpueJjKqNwmuxBpe4AcumCilmF/tM0EZucGD40JjoAJBQydLygmmoucp5KMNAr+xrp3JNC10T3HvtwTwnxwk00deEiHY5BctyIaS63hqFml1pIF69bL7+lsVfaw8IvtFBypGvcJPiUSbQVlj9zSU7ur+q7be/KUtvL99X+ZgyoGgrGmrE/qKubb6S9G8YtMWSy57CE1RHcZNjXMOIQ0PJlRMLpzH1KZQLHn3Pnu/vN/tAkSCgLExVo3DOteaanT0ve+Nxp8feNORb0OtKvlcpLgB7ke+VziZRx0Rlhvao2DmjIcoe9Re8uUszLyQf+c6rpiiCe9L1N6V+6WBSB4nYEe/s6kQ/dsu3St2ttePKXdsV2QhhrsupBv2qk8LL0AFJT9ECqAqRHQkVCB2EJLd/zRNdSSwJ2xWhJ42t6PKSfLrPXlLQKN1GCLSp+6io/6p0RD2dvVrwY5gtD309krKOdD9nqGvbZlIm1oq/zKuH0BoKN5JQ4qCI8ju9J0RjMD53vtQnMbD7mKVE0iaS1Q8Rk+2fMDZGMEkLo="
+
 cache:
   directories:
   - ".gradle"
   - "$HOME/.gradle"
+
+stages:
+  - name: build
+  - name: snapshot
+    if: branch = master AND NOT (type = pull_request)
+
+jobs:
+  include:
+    - stage: build
+      script: ./gradlew build
+    - stage: snapshot
+      script: ./gradlew publishToRepo -PpublishUrl=jcenterSnapshot -PpublishUsername=$BINTRAY_USER -PpublishPassword=$BINTRAY_KEY
+
 notifications:
   slack:
     matrix:

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath group: 'com.github.jengelman.gradle.plugins', name:'shadow', version: shadowGradlePlugin
+        classpath "com.github.jengelman.gradle.plugins:shadow:${shadowGradlePlugin}"
+        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:${bintrayPluginVersion}"
+        classpath "org.ajoberstar:gradle-git:${gradleGitPluginVersion}"
     }
 }
 
@@ -23,8 +25,11 @@ apply plugin: 'checkstyle'
 apply from: 'gradle/java.gradle'
 apply from: 'gradle/maven.gradle'
 
-group = 'io.pravega'
-version = connectorVersion
+apply from: 'gradle/bintray.gradle'
+apply plugin: 'org.ajoberstar.grgit'
+
+group = "io.pravega"
+version = getProjectVersion()
 
 description = """Pravega Hadoop Connector(pravega-inputformat)"""
 
@@ -101,4 +106,15 @@ javadoc {
     title = "Pravega Hadoop Connector"
     failOnError = false
     exclude "**/impl/**";
+}
+
+def getProjectVersion() {
+    String ver = connectorVersion
+    if (ver.contains("-SNAPSHOT")) {
+        String versionLabel = ver.substring(0, ver.indexOf("-SNAPSHOT"))
+        def count = grgit.log(includes:['HEAD']).size()
+        def commitId = "${grgit.head().abbreviatedId}"
+        ver = versionLabel + "-" + count + "." + commitId + "-SNAPSHOT"
+    }
+    return ver
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,7 @@
 # 3rd party Versions.
 checkstyleToolVersion=7.1
 curatorVersion=4.0.0
+gradleGitPluginVersion=1.7.2
 gsonVersion=2.8.2
 hadoopVersion=2.8.1
 junitVersion=4.12
@@ -24,3 +25,10 @@ signing.keyId=05949AF6
 # signing.password=
 # This will be defaulted to ~/.gnupg/secring.gpg if not provided as a command line property
 signing.secretKeyRingFile=
+
+# bintray configurations
+bintrayPluginVersion=1.7.3
+bintrayRepoName=pravega
+bintrayPackageName=pravega-connectors-hadoop
+bintrayOrgName=pravega
+autoPublish=true

--- a/gradle/bintray.gradle
+++ b/gradle/bintray.gradle
@@ -32,7 +32,7 @@ if (project.hasProperty("publishRepo") && publishRepo == "bintrayRelease") {
 }
 
 def pomConfig = {
-    name "Pravega Haddopo Connectors"
+    name "Pravega Hadoop Connectors"
     url "http://pravega.io"
     description "Streaming Storage Platform"
     scm {
@@ -75,7 +75,6 @@ task publishToBintray (dependsOn: 'bintrayUpload') {
 
                     root.children().last() + pomConfig
                 }
-
             }
         }
     }

--- a/gradle/bintray.gradle
+++ b/gradle/bintray.gradle
@@ -1,0 +1,82 @@
+import java.text.SimpleDateFormat
+
+apply plugin: 'com.jfrog.bintray'
+apply plugin: 'maven-publish'
+apply plugin: 'maven'
+
+if (project.hasProperty("publishRepo") && publishRepo == "bintrayRelease") {
+    bintray {
+        if (!project.hasProperty("publishUsername") || !project.hasProperty("publishPassword")) {
+            throw new GradleException("missing bintray publishing credentials")
+        }
+        user = publishUsername
+        key = publishPassword
+        pkg {
+            repo = "${bintrayRepoName}"
+            name = "${bintrayPackageName}"
+            userOrg = "${bintrayOrgName}"
+            licenses = ['Apache-2.0']
+            publish = "${autoPublish}"
+            vcsUrl = 'https://github.com/pravega/hadoop-connectors.git'
+            version {
+                desc = 'Hadoop Pravega Connector Artifacts'
+                SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZZ")
+                released = sdf.format(new Date())
+                gpg {
+                    sign = true
+                }
+            }
+        }
+        publications = ['bintrayPublication']
+    }
+}
+
+def pomConfig = {
+    name "Pravega Haddopo Connectors"
+    url "http://pravega.io"
+    description "Streaming Storage Platform"
+    scm {
+        url 'https://github.com/pravega/hadoop-connectors/tree/master'
+        connection 'scm:git:git://github.com/pravega/hadoop-connectors.git'
+        developerConnection 'scm:git:https://github.com/pravega/hadoop-connectors.git'
+    }
+    licenses {
+        license {
+            name 'The Apache License, Version 2.0'
+            url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+        }
+    }
+}
+
+task publishToBintray (dependsOn: 'bintrayUpload') {
+    publishing {
+        publications {
+            bintrayPublication(MavenPublication) { publication ->
+
+                artifactId project.archivesBaseName
+                project.shadow.component(publication)
+                artifact sourceJar
+                artifact javadocJar
+
+                pom.withXml { xml ->
+
+                    def root = xml.asNode()
+
+                    def dependenciesNode = asNode().getAt("dependencies")[0]
+                    project.configurations.shadowOnly.allDependencies.each { dep ->
+                        if (!(dep instanceof SelfResolvingDependency)) {
+                            def dependencyNode = dependenciesNode.appendNode('dependency')
+                            dependencyNode.appendNode('groupId', dep.group)
+                            dependencyNode.appendNode('artifactId', dep.name)
+                            dependencyNode.appendNode('version', dep.version)
+                            dependencyNode.appendNode('scope', 'provided')
+                        }
+                    }
+
+                    root.children().last() + pomConfig
+                }
+
+            }
+        }
+    }
+}

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -14,7 +14,7 @@ compileJava {
     ])
 }
 
-archivesBaseName = "hadoop-connectors"
+archivesBaseName = "pravega-connectors-hadoop"
 
 assemble.dependsOn(shadowJar)
 

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -35,6 +35,13 @@ uploadShadow {
                         authentication(userName: publishUsername, password: publishPassword)
                     }
                 }
+                else if (publishUrl == "jcenterSnapshot") {
+                    repository(url: "https://oss.jfrog.org/artifactory/oss-snapshot-local/") {
+                        if (project.hasProperty("publishUsername") && project.hasProperty("publishPassword")) {
+                            authentication(userName: publishUsername, password: publishPassword)
+                        }
+                    }
+                }
                 else {
                     repository(url: publishUrl) {
                         // Only configure credentials if they are provided (allows publishing to the filesystem)
@@ -48,8 +55,8 @@ uploadShadow {
     }
 }
 
-task publish(dependsOn: uploadShadow) {
-    description = "Publish all artifacts to a repository"
+task publishToRepo(dependsOn: uploadShadow) {
+    description = "Publish all artifacts to repository"
 }
 
 tasks.withType(Upload) {

--- a/src/main/java/io/pravega/connectors/hadoop/PravegaInputFormat.java
+++ b/src/main/java/io/pravega/connectors/hadoop/PravegaInputFormat.java
@@ -70,8 +70,8 @@ public class PravegaInputFormat<V> extends InputFormat<EventKey, V> {
 
     /**
      * Generates splits which can be used by hadoop mapper to read pravega segments in parallel.
-     * <p>
-     * <p>The number of created input splits is equivalent to the parallelism of the source. For each input split,
+     *
+     * The number of created input splits is equivalent to the parallelism of the source. For each input split,
      * a Pravega batch client will be created to read from the specified Pravega segment. Each input split is closed when
      * the nextKeyValue() returns false.
      *


### PR DESCRIPTION
This is a similar code change of https://github.com/pravega/flink-connectors/pull/129

Test
- docker run --name artifactory -d -p 8081:8081 docker.bintray.io/jfrog/artifactory-oss
- ./gradlew
 publishToRepo -PpublishUrl=http://localhost:8081/artifactory/example-repo-local/ -PpublishUsername=admin -PpublishPassword=password
- http://localhost:8081/artifactory/example-repo-local/io/pravega/hadoop-connectors/
hadoop-connectors-0.3.0-16.4331d47-20180523.183352-1-javadoc.jar   23-May-2018 18:33  31.84 KB
hadoop-connectors-0.3.0-16.4331d47-20180523.183352-1-sources.jar   23-May-2018 18:33  6.76 KB
hadoop-connectors-0.3.0-16.4331d47-20180523.183352-1.jar           23-May-2018 18:33  22.43 MB
hadoop-connectors-0.3.0-16.4331d47-20180523.183352-1.pom           23-May-2018 18:33  1.55 KB
maven-metadata.xml                                                 23-May-2018 18:33  374 bytes

Also uploaded to jfrog

https://oss.jfrog.org/artifactory/jfrog-dependencies/io/pravega/pravega-connectors-hadoop/0.3.0-18.a042f0c-SNAPSHOT/
../
maven-metadata.xml                                                         24-May-2018 21:40  1.23 KB
pravega-connectors-hadoop-0.3.0-18.a042f0c-20180524.214012-1-javadoc.jar   24-May-2018 21:40  33.24 KB
pravega-connectors-hadoop-0.3.0-18.a042f0c-20180524.214012-1-sources.jar   24-May-2018 21:40  6.79 KB
pravega-connectors-hadoop-0.3.0-18.a042f0c-20180524.214012-1.jar           24-May-2018 21:40  22.43 MB
pravega-connectors-hadoop-0.3.0-18.a042f0c-20180524.214012-1.pom           24-May-2018 21:40  1.55 KB