### PR TITLE
[issue-43] Update version info from r0.3 branch (release-prep 0.3.0)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,8 +21,8 @@ shadowGradlePlugin=2.0.1
 slf4jApiVersion=1.7.25
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.3.0-SNAPSHOT
-pravegaVersion=0.3.0-50.5f4d75b-SNAPSHOT
+connectorVersion=0.3.0
+pravegaVersion=0.3.0
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
 usePravegaVersionSubModule=false


### PR DESCRIPTION
This PR fixes the issue https://github.com/pravega/hadoop-connectors/issues/43

  * updated pravega and connector version to 0.3.0
   * updated pravega submodule to v0.3.0-rc0

Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>