### PR TITLE
[issue-54] Change version in r0.3 branch in preparation for release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,8 +21,8 @@ shadowGradlePlugin=2.0.1
 slf4jApiVersion=1.7.25
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.3.1-SNAPSHOT
-pravegaVersion=0.3.0
+connectorVersion=0.3.1
+pravegaVersion=0.3.1
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
 usePravegaVersionSubModule=false


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

  * updated pravega and connector version to 0.3.1
  * updated pravega submodule commit to pravega 0.3.1 release commit id

**Purpose of the change**
To address the issue https://github.com/pravega/hadoop-connectors/issues/54

**What the code does**
build file changes

**How to verify it**
run `./gradlew clean build` and make sure the build succeeds