### PR TITLE
[issue-58] Update Connector version to 0.3.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,8 +21,8 @@ shadowGradlePlugin=2.0.1
 slf4jApiVersion=1.7.25
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.3.2-SNAPSHOT
-pravegaVersion=0.3.1
+connectorVersion=0.3.2
+pravegaVersion=0.3.2
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
 usePravegaVersionSubModule=false


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
  * updated connector and pravega version to 0.3.2
  * updated pravega sub-module commit to pravega v0.3.2 latest commit

**Purpose of the change**
To address https://github.com/pravega/hadoop-connectors/issues/58

**What the code does**
build configuration changes to use appropriate Pravega version

**How to verify it**
`./gradlew clean build` should pass