### PR TITLE
[issue-62] Update Pravega version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ slf4jApiVersion=1.7.25
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.4.0-SNAPSHOT
-pravegaVersion=0.4.0-50.63aea88-SNAPSHOT
+pravegaVersion=0.4.0-50.da91e55-SNAPSHOT
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
 usePravegaVersionSubModule=false

--- a/src/test/java/io/pravega/connectors/hadoop/utils/SetupUtils.java
+++ b/src/test/java/io/pravega/connectors/hadoop/utils/SetupUtils.java
@@ -85,11 +85,17 @@ public final class SetupUtils {
                 .isInProcSegmentStore(true)
                 .segmentStoreCount(1)
                 .containerCount(4)
+                .enableTls(false)
                 // to match code change https://github.com/pravega/pravega/pull/2476
                 .keyFile("")
                 .certFile("")
+                .enableAuth(false)
                 .userName("")
                 .passwd("")
+                .passwdFile("")
+                .jksKeyFile("")
+                .jksTrustFile("")
+                .keyPasswordFile("")
                 .build();
         this.inProcPravegaCluster.setControllerPorts(new int[]{controllerPort});
         this.inProcPravegaCluster.setSegmentStorePorts(new int[]{hostPort});


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**

  * updated Pravega version to 0.4.0-50.da91e55-SNAPSHOT
  * updated Pravega submodule commit to da91e5518b9797306e94bb383508e59a96f3bc23
  * replaced deprecated BatchClient's getStreamInfo with StreamManager's getStreamInfo
  * fixed failing test cases

**Purpose of the change**
To address https://github.com/pravega/hadoop-connectors/issues/62

**What the code does**
Updates Pravega dependency to latest published artifact.

**How to verify it**
`./gradlew clean build` should pass
