### PR TITLE
[issue-65] Update connector to support Pravega client API refactor

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,12 +16,12 @@ hadoopVersion=2.8.1
 junitVersion=4.12
 mockitoVersion=1.10.19
 scalaVersion=2.11.8
-shadowGradlePlugin=2.0.1
+shadowGradlePlugin=2.0.3
 slf4jApiVersion=1.7.25
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.4.0-SNAPSHOT
-pravegaVersion=0.4.0-50.da91e55-SNAPSHOT
+pravegaVersion=0.5.0-49.b80b627-SNAPSHOT
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
 usePravegaVersionSubModule=false

--- a/src/main/java/io/pravega/connectors/hadoop/PravegaOutputFormat.java
+++ b/src/main/java/io/pravega/connectors/hadoop/PravegaOutputFormat.java
@@ -11,7 +11,8 @@
 package io.pravega.connectors.hadoop;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.pravega.client.ClientFactory;
+import io.pravega.client.EventStreamClientFactory;
+import io.pravega.client.ClientConfig;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.Serializer;
@@ -79,7 +80,7 @@ public class PravegaOutputFormat<V> extends OutputFormat<NullWritable, V> {
                                                   String streamName,
                                                   URI controllerURI,
                                                   String serializerClassName) throws IOException {
-        ClientFactory clientFactory = getClientFactory(scopeName, controllerURI);
+        EventStreamClientFactory clientFactory = getClientFactory(scopeName, controllerURI);
         Object serializerInstance = getInstanceFromName(serializerClassName);
         if (!Serializer.class.isAssignableFrom(serializerInstance.getClass())) {
             throw new IOException(serializerInstance.getClass() + " is not a type of Serializer");
@@ -90,8 +91,9 @@ public class PravegaOutputFormat<V> extends OutputFormat<NullWritable, V> {
     }
 
     @VisibleForTesting
-    protected ClientFactory getClientFactory(String scope, URI controllerUri) {
-        return ClientFactory.withScope(scope, controllerUri);
+    protected EventStreamClientFactory getClientFactory(String scope, URI controllerUri) {
+        ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
+        return EventStreamClientFactory.withScope(scope, clientConfig);
     }
 
     private PravegaOutputRecordWriter<V> getOutputRecordWriter(Configuration conf) throws IOException {

--- a/src/test/java/io/pravega/connectors/hadoop/PravegaInputRecordReaderTest.java
+++ b/src/test/java/io/pravega/connectors/hadoop/PravegaInputRecordReaderTest.java
@@ -12,8 +12,7 @@ package io.pravega.connectors.hadoop;
 
 import io.pravega.client.batch.SegmentRange;
 import io.pravega.client.batch.impl.SegmentRangeImpl;
-import io.pravega.client.ClientFactory;
-import io.pravega.client.batch.BatchClient;
+import io.pravega.client.BatchClientFactory;
 import io.pravega.client.batch.SegmentIterator;
 import io.pravega.client.batch.impl.SegmentIteratorImpl;
 import io.pravega.client.segment.impl.Segment;
@@ -41,9 +40,8 @@ public class PravegaInputRecordReaderTest {
     private PravegaInputRecordReader<Integer> reader;
     private Segment segment;
     private PravegaInputSplit split;
-    private ClientFactory mockClientFactory;
+    private BatchClientFactory mockClientFactory;
     private SegmentIterator<Integer> mockIterator;
-    private BatchClient mockBatchClient;
 
     @Before
     public void setupTests() throws Exception {
@@ -56,7 +54,7 @@ public class PravegaInputRecordReaderTest {
         TaskAttemptContext ctx = mockTaskAttemptContextImpl();
         reader.initialize(split, ctx);
         verify(ctx).getConfiguration();
-        verify(mockBatchClient).readSegment(anyObject(), anyObject());
+        verify(mockClientFactory).readSegment(anyObject(), anyObject());
     }
 
     @Test
@@ -92,18 +90,11 @@ public class PravegaInputRecordReaderTest {
         return mockTaskAttemptContextImpl;
     }
 
-    private ClientFactory mockClientFactory() {
-        ClientFactory mockClientFactory = mock(ClientFactory.class);
-        mockBatchClient = mockBatchClient();
-        Mockito.doReturn(mockBatchClient).when(mockClientFactory).createBatchClient();
-        return mockClientFactory;
-    }
-
-    private BatchClient mockBatchClient() {
-        BatchClient mockBatchClient = mock(BatchClient.class);
+    private BatchClientFactory mockClientFactory() {
+        BatchClientFactory mockClientFactory = mock(BatchClientFactory.class);
         mockIterator = mockIterator();
-        Mockito.doReturn(mockIterator).when(mockBatchClient).readSegment(anyObject(), anyObject());
-        return mockBatchClient;
+        Mockito.doReturn(mockIterator).when(mockClientFactory).readSegment(anyObject(), anyObject());
+        return mockClientFactory;
     }
 
     private SegmentIterator<Integer> mockIterator() {

--- a/src/test/java/io/pravega/connectors/hadoop/PravegaOutputFormatTest.java
+++ b/src/test/java/io/pravega/connectors/hadoop/PravegaOutputFormatTest.java
@@ -10,7 +10,7 @@
 
 package io.pravega.connectors.hadoop;
 
-import io.pravega.client.ClientFactory;
+import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.Serializer;
@@ -128,7 +128,7 @@ public class PravegaOutputFormatTest {
     }
 
     private void mockClientFactory(PravegaOutputFormat<String> spyPravegaOutputFormat) {
-        ClientFactory mockClientFactory = mock(ClientFactory.class);
+        EventStreamClientFactory mockClientFactory = mock(EventStreamClientFactory.class);
         when(spyPravegaOutputFormat.getClientFactory(anyString(), anyObject())).thenReturn(mockClientFactory);
         when(mockClientFactory.createEventWriter(anyString(),
                 any(Serializer.class),


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
  * Updated Pravega to latest snapshot version 0.5.0-49.b80b627-SNAPSHOT
  * Updated Pravega sub-module to the commit point of snapshot version
  * Updated shadow gradle plugin version to fix the shade dependency issue
  * Fixed unit/integration tests

**Purpose of the change**
To address the issue https://github.com/pravega/hadoop-connectors/issues/65

**What the code does**
- Updated Pravega artifact and submodule version to latest snapshot
- Addressed the Pravega client API refactoring changes. 
- Fixed unit/integration tests.

**How to verify it**
`./gradlew clean build` should pass

