### PR TITLE
[issue-67] Update Pravega version to 0.4.0-RC2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ slf4jApiVersion=1.7.25
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.4.0-SNAPSHOT
-pravegaVersion=0.4.0-50.da91e55-SNAPSHOT
+pravegaVersion=0.4.0-2010.7a9bdb4-SNAPSHOT
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
 usePravegaVersionSubModule=false


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
- updated Pravega artifacts to `0.4.0-RC2`
- updated Pravega sub module commit id

**Purpose of the change**
To address https://github.com/pravega/hadoop-connectors/issues/67

**What the code does**
updates build configuration to support `0.4.0-rc2` version of Pravega

**How to verify it**
`./gradlew clean build` should succeed