### PR TITLE
[Issue-69] Update Pravega to 0.4.0-RC5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ slf4jApiVersion=1.7.25
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.4.0-SNAPSHOT
-pravegaVersion=0.4.0-2010.7a9bdb4-SNAPSHOT
+pravegaVersion=0.4.0-2030.d99411b-SNAPSHOT
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
 usePravegaVersionSubModule=false


### PR DESCRIPTION
Signed-off-by: Elizabeth Bain <elizabeth.bain@emc.com>

**Change log description**
  * updated Pravega version to v0.4.0-rc5
  * updated Pravega submodule commit to d99411b1cb805f9d6c7374db566801e7eb724851

**Purpose of the change**
To address the issue https://github.com/pravega/hadoop-connectors/issues/69

**What the code does**
build configuration changes

**How to verify it**
./gradlew clean build should pass