### PR TITLE
[issue-71] Prepare connector for 0.4.0 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,8 +20,8 @@ shadowGradlePlugin=2.0.1
 slf4jApiVersion=1.7.25
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.4.0-SNAPSHOT
-pravegaVersion=0.4.0-2030.d99411b-SNAPSHOT
+connectorVersion=0.4.0
+pravegaVersion=0.4.0
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
 usePravegaVersionSubModule=false


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
  * updated Pravega version to 0.4.0
  * updated connector version to 0.4.0

**Purpose of the change**
To address the issue https://github.com/pravega/hadoop-connectors/issues/71

**What the code does**
build configuration changes

**How to verify it**
`./gradlew clean build` should pass