### PR TITLE
[issue-78] Update connector to use Pravega r0.5 artifacts

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ slf4jApiVersion=1.7.25
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.5.0-SNAPSHOT
-pravegaVersion=0.5.0-50.59e3614-SNAPSHOT
+pravegaVersion=0.5.0-2223.ce3ba81-SNAPSHOT
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
 usePravegaVersionSubModule=false


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
Updated Pravega artifact version to `r0.5` artifact

**Purpose of the change**
To address https://github.com/pravega/hadoop-connectors/issues/78

**What the code does**
build configuration change

**How to verify it**
`./gradlew clean build` should pass