### PR TITLE
[issue-52] Add distribution publishing configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,35 @@ shadowJar {
     relocate 'com.google', 'io.pravega.shaded.com.google'
 }
 
+distributions {
+    release {
+        contents {
+            from shadowJar
+            from javadocJar
+            from sourceJar
+        }
+    }
+    workspace {
+        contents {
+            from ('.') {
+                exclude "build"
+                exclude ".gradle"
+                exclude ".github"
+                exclude ".idea"
+                exclude "out"
+                exclude "pravega/*"
+                exclude "target"
+                exclude "*.log"
+            }
+        }
+    }
+}
+
+task distribution(type: Copy, dependsOn: [installReleaseDist, installWorkspaceDist, assembleWorkspaceDist]) {
+    from ("$buildDir/install/hadoop-connectors-release")
+    into ("$buildDir/distributions")
+}
+
 javadoc {
     title = "Pravega Hadoop Connector"
     failOnError = false

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -10,6 +10,7 @@
  */
 
 apply plugin: 'java'
+apply plugin: 'distribution'
 apply plugin: 'com.github.johnrengelman.shadow'
 
 compileJava {


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
 - added configurations to assemble artifacts for distribution

**Purpose of the change**
Fixes https://github.com/pravega/hadoop-connectors/issues/52

**What the code does**
  - added new build task to assemble release artifacts to a specific directory location

**How to verify it**
run `./gradlew clean distribution` and verify the release artifacts under `$buildDir/distributions`