### PR TITLE
[issue-94] Configure travis build to use JDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@
 language: java
 install: true
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 # the secure configurations in env: section is for BINTRAY_USER=<USER> and BINTRAY_KEY=<KEY> properties
 # which will be used for publishing artifacts to snapshot repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 language: java
+install: true
+jdk:
+  - oraclejdk8
+
 # the secure configurations in env: section is for BINTRAY_USER=<USER> and BINTRAY_KEY=<KEY> properties
 # which will be used for publishing artifacts to snapshot repository
 env:


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
- Configure travis build to use JDK 8

**Purpose of the change**
Fixes https://github.com/pravega/hadoop-connectors/issues/94

**What the code does**
updated travis configuration to force hadoop connector build to use JDK 8

**How to verify it**
`./gradlew clean build` should pass
