### PR TITLE
[issue-98] Update connector version in r0.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ shadowGradlePlugin=2.0.3
 slf4jApiVersion=1.7.25
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.5.0
+connectorVersion=0.5.1-SNAPSHOT
 pravegaVersion=0.5.0
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
  * bumped the version label to 0.5.1-SNAPSHOT

**Purpose of the change**
Fixes https://github.com/pravega/hadoop-connectors/issues/98

**What the code does**
updates the connection version

**How to verify it**
./gradlew clean build should pass