### PR TITLE
[Issue-93] Remove-year-from-copyright-header

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,1 @@
+Copyright (c) 2017-2020 Dell Inc., or its subsidiaries. All Rights Reserved.

--- a/src/main/java/io/pravega/connectors/hadoop/AbstractPravegaBuilder.java
+++ b/src/main/java/io/pravega/connectors/hadoop/AbstractPravegaBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/pravega/connectors/hadoop/EventKey.java
+++ b/src/main/java/io/pravega/connectors/hadoop/EventKey.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/pravega/connectors/hadoop/PravegaClientConfig.java
+++ b/src/main/java/io/pravega/connectors/hadoop/PravegaClientConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/pravega/connectors/hadoop/PravegaConfig.java
+++ b/src/main/java/io/pravega/connectors/hadoop/PravegaConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/pravega/connectors/hadoop/PravegaEventRouter.java
+++ b/src/main/java/io/pravega/connectors/hadoop/PravegaEventRouter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/pravega/connectors/hadoop/PravegaInputFormat.java
+++ b/src/main/java/io/pravega/connectors/hadoop/PravegaInputFormat.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/pravega/connectors/hadoop/PravegaInputFormatBuilder.java
+++ b/src/main/java/io/pravega/connectors/hadoop/PravegaInputFormatBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/pravega/connectors/hadoop/PravegaInputRecordReader.java
+++ b/src/main/java/io/pravega/connectors/hadoop/PravegaInputRecordReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/pravega/connectors/hadoop/PravegaInputSplit.java
+++ b/src/main/java/io/pravega/connectors/hadoop/PravegaInputSplit.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/pravega/connectors/hadoop/PravegaOutputFormatBuilder.java
+++ b/src/main/java/io/pravega/connectors/hadoop/PravegaOutputFormatBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/pravega/connectors/hadoop/EventKeyTest.java
+++ b/src/test/java/io/pravega/connectors/hadoop/EventKeyTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/pravega/connectors/hadoop/PravegaConnectorLocalJobITCase.java
+++ b/src/test/java/io/pravega/connectors/hadoop/PravegaConnectorLocalJobITCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/pravega/connectors/hadoop/PravegaConnectorMiniYarnITCase.java
+++ b/src/test/java/io/pravega/connectors/hadoop/PravegaConnectorMiniYarnITCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/pravega/connectors/hadoop/PravegaInputFormatITCase.java
+++ b/src/test/java/io/pravega/connectors/hadoop/PravegaInputFormatITCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/pravega/connectors/hadoop/PravegaInputFormatTest.java
+++ b/src/test/java/io/pravega/connectors/hadoop/PravegaInputFormatTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/pravega/connectors/hadoop/PravegaInputRecordReaderITCase.java
+++ b/src/test/java/io/pravega/connectors/hadoop/PravegaInputRecordReaderITCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/pravega/connectors/hadoop/PravegaInputRecordReaderTest.java
+++ b/src/test/java/io/pravega/connectors/hadoop/PravegaInputRecordReaderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/pravega/connectors/hadoop/PravegaInputSplitTest.java
+++ b/src/test/java/io/pravega/connectors/hadoop/PravegaInputSplitTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/pravega/connectors/hadoop/PravegaOutputFormatTest.java
+++ b/src/test/java/io/pravega/connectors/hadoop/PravegaOutputFormatTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/pravega/connectors/hadoop/PravegaOutputRecordWriterTest.java
+++ b/src/test/java/io/pravega/connectors/hadoop/PravegaOutputRecordWriterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/pravega/connectors/hadoop/SimpleMapper.java
+++ b/src/test/java/io/pravega/connectors/hadoop/SimpleMapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/pravega/connectors/hadoop/SumReducer.java
+++ b/src/test/java/io/pravega/connectors/hadoop/SumReducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/pravega/connectors/hadoop/TokenizerMapper.java
+++ b/src/test/java/io/pravega/connectors/hadoop/TokenizerMapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/pravega/connectors/hadoop/utils/IntegerSerializer.java
+++ b/src/test/java/io/pravega/connectors/hadoop/utils/IntegerSerializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/pravega/connectors/hadoop/utils/SetupUtils.java
+++ b/src/test/java/io/pravega/connectors/hadoop/utils/SetupUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/pravega/connectors/hadoop/utils/TestUtils.java
+++ b/src/test/java/io/pravega/connectors/hadoop/utils/TestUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Signed-off-by: AlexanderZhao1 <Alexander_Zhao@dell.com>

**Change log description**
* Removes year from copyright as per legal requirements.
* Add NOTICE file

**Purpose of the change**
fix #93 

**What the code does**

As [pravega/pravega#3508](https://github.com/pravega/pravega/issues/3508) mentioned,

> Like with Apache projects, the year of copyright is specified in a NOTICE file, which we update every year. The NOTICE file is suppose to contain the following text:
`Copyright (c) 2017-XXXX Dell Inc., or its subsidiaries. All Rights Reserved.`

So add a NOTICE file with the following line:
``Copyright (c) 2017-2020 Dell Inc., or its subsidiaries. All Rights Reserved.``

 > The year of the header is supposed to represent the year of first publication, which is currently incorrect for files created in 2018 and 2019. Consequently, we either change that or make a bulk delete of the year in the source header of all files. I recommend we do the latter and our legal supports that option as long as we do the other next step.

So There is no code change, only changes to the license header from
`Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.`
to
`Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.`

in all files.

**How to verify it**

`./gradlew clean build` should pass
