### PR TITLE
[issue-115] Fix the typo of wrong version name

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ shadowGradlePlugin=2.0.3
 slf4jApiVersion=1.7.25
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.7.0-SANPSHOT
+connectorVersion=0.7.0-SNAPSHOT
 pravegaVersion=0.7.0-50.be42b9d-SNAPSHOT
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'


### PR DESCRIPTION
Signed-off-by: AlexanderZhao1 <Alexander_Zhao@dell.com>

**Change log description**
Change the spelling mistake of `SANPSHOT` in 
`gradle.properties`

**Purpose of the change**
fix #115 

**What the code does**

Change from `0.7.0-SANPSHOT` to `0.7.0-SNAPSHOT`

**How to verify it**

`./gradlew clean build` should pass
