### PR TITLE
[issue-118] Import the correct dependency

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ slf4jApiVersion=1.7.25
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.7.0-SNAPSHOT
-pravegaVersion=0.7.0-50.be42b9d-SNAPSHOT
+pravegaVersion=0.7.0-50.d513b90-SNAPSHOT
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
 usePravegaVersionSubModule=false

--- a/src/test/java/io/pravega/connectors/hadoop/PravegaInputFormatITCase.java
+++ b/src/test/java/io/pravega/connectors/hadoop/PravegaInputFormatITCase.java
@@ -35,8 +35,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import static io.pravega.shared.segment.StreamSegmentNameUtils.computeSegmentId;
-import static io.pravega.shared.segment.StreamSegmentNameUtils.getSegmentNumber;
+import static io.pravega.shared.NameUtils.computeSegmentId;
+import static io.pravega.shared.NameUtils.getSegmentNumber;
 
 public class PravegaInputFormatITCase extends ConnectorBaseITCase {
 


### PR DESCRIPTION
Signed-off-by: Brian Zhou <brian.zhou@emc.com>

**Change log description**
 - Import the correct dependency

**Purpose of the change**
Fixes #118 

**What the code does**
Update the pravega version to latest master
import `io.pravega.shared.NameUtils` instead of `io.pravega.shared.segment.StreamSegmentNameUtils`

**How to verify it**
`./gradlew clean build` passes