### PR TITLE
[issue-120] Prepare for 0.6.2 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,8 +21,8 @@ shadowGradlePlugin=2.0.3
 slf4jApiVersion=1.7.25
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.6.2-SNAPSHOT
-pravegaVersion=0.6.1
+connectorVersion=0.6.2
+pravegaVersion=0.6.2
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
 usePravegaVersionSubModule=false


### PR DESCRIPTION
Signed-off-by: Brian Zhou <brian.zhou@emc.com>

**Change log description**
- Prepare for the `0.6.2` release

**Purpose of the change**
Fix #120  

**What the code does**
Update the connector version into `0.6.2`
Update the Pravega client version into `0.6.2`

**How to verify it**
`./gradlew clean build` passes