### PR TITLE
[issue-135] Change the usage of ControllerImpl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ repositories {
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
         maven { url "https://repository.apache.org/snapshots" }
         maven { url "https://oss.jfrog.org/jfrog-dependencies" }
+        maven { url "https://oss.sonatype.org/content/repositories/iopravega-1089" }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ slf4jApiVersion=1.7.25
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.8.0-SNAPSHOT
-pravegaVersion=0.8.0-2540.5314cfd-SNAPSHOT
+pravegaVersion=0.8.0
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
 usePravegaVersionSubModule=false

--- a/src/test/java/io/pravega/connectors/hadoop/PravegaInputFormatITCase.java
+++ b/src/test/java/io/pravega/connectors/hadoop/PravegaInputFormatITCase.java
@@ -10,10 +10,11 @@
 
 package io.pravega.connectors.hadoop;
 
+import io.pravega.client.control.impl.Controller;
+import io.pravega.client.control.impl.ControllerImpl;
+import io.pravega.client.control.impl.ControllerImplConfig;
 import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.Stream;
-import io.pravega.client.stream.impl.ControllerImpl;
-import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.client.stream.impl.StreamImpl;
 import io.pravega.connectors.hadoop.utils.IntegerSerializer;
 import io.pravega.connectors.hadoop.utils.SetupUtils;
@@ -46,7 +47,7 @@ public class PravegaInputFormatITCase extends ConnectorBaseITCase {
     private static final SetupUtils SETUP_UTILS = new SetupUtils();
 
     private ScheduledExecutorService executor;
-    private ControllerImpl controller = null;
+    private Controller controller = null;
     private EventStreamWriter<Integer> writer;
 
     @Before

--- a/src/test/java/io/pravega/connectors/hadoop/utils/SetupUtils.java
+++ b/src/test/java/io/pravega/connectors/hadoop/utils/SetupUtils.java
@@ -18,9 +18,6 @@ import io.pravega.client.admin.StreamManager;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamCut;
-import io.pravega.client.stream.impl.Controller;
-import io.pravega.client.stream.impl.ControllerImpl;
-import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.client.stream.impl.DefaultCredentials;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.client.stream.impl.StreamCutImpl;
@@ -204,17 +201,6 @@ public final class SetupUtils {
                 .withCredentials(new DefaultCredentials(PRAVEGA_PASSWORD, PRAVEGA_USERNAME))
                 .withHostnameValidation(enableHostNameValidation)
                 .withTrustStore(trustStoreCertFile);
-    }
-
-    /**
-     * Create a controller facade for this cluster.
-     * @return The controller facade, which must be closed by the caller.
-     */
-    public Controller newController() {
-        ControllerImplConfig config = ControllerImplConfig.builder()
-                .clientConfig(getClientConfig())
-                .build();
-        return new ControllerImpl(config, DEFAULT_SCHEDULED_EXECUTOR_SERVICE);
     }
 
     /**


### PR DESCRIPTION
**Change log description**
 - Update the Pravega client
 - Change the usage of ControllerImpl

**Purpose of the change**
Fixes #135 

**What the code does**
 - Update the Pravega client to 0.8.0 RC1
 - Remove the usage of `ControllerImpl` in `SetupUtils`
 - Change the import package of the `ControllerImpl` in `PravegaInputFormatITCase`

**How to verify it**
`./gradlew clean build` passes