### PR TITLE
[issue-137] Prepare for 0.8.0 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,6 @@ repositories {
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
         maven { url "https://repository.apache.org/snapshots" }
         maven { url "https://oss.jfrog.org/jfrog-dependencies" }
-        maven { url "https://oss.sonatype.org/content/repositories/iopravega-1089" }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ shadowGradlePlugin=2.0.3
 slf4jApiVersion=1.7.25
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.8.0-SNAPSHOT
+connectorVersion=0.8.0
 pravegaVersion=0.8.0
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'


### PR DESCRIPTION
**Change log description**
Prepare for the 0.8.0 release

**Purpose of the change**
Fix #137 

**What the code does**
Update the connector version into 0.8.0
Update the Pravega client version into 0.8.0

**How to verify it**
`./gradlew clean build` should pass