### PR TITLE
Issue 154 fail to publish the artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 11
         uses: actions/setup-java@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ env:
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -33,6 +34,13 @@ jobs:
           # and we will rerun the download to get the newest packages
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
+        # build cache is used when we need to publish the artifact
+      - name: Cache build outputs
+        uses: actions/cache@v2
+        with:
+          path: ./*
+          key: ${{ github.run_id }}
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
@@ -40,6 +48,7 @@ jobs:
         run: ./gradlew clean build
 
   snapshot:
+    name: Publish snapshot
     needs: [build]
     runs-on: ubuntu-latest
     # only publish the snapshot when it is a push on the master or the release branch (starts with r0.x or r1.x)
@@ -48,5 +57,22 @@ jobs:
       BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
       BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
     steps:
+        # see comments above
+      - name: Cache gradle modules
+        uses: actions/cache@v2
+        with:
+          path: |
+            .gradle
+            $HOME/.gradle
+            $HOME/.m2
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+
+        # see comments above
+      - name: Cache build outputs
+        uses: actions/cache@v2
+        with:
+          path: ./*
+          key: ${{ github.run_id }}
+
       - name: Publish to repo
         run: ./gradlew publishToRepo -PpublishUrl=jcenterSnapshot -PpublishUsername=$BINTRAY_USER -PpublishPassword=$BINTRAY_KEY


### PR DESCRIPTION
Signed-off-by: zhongle.wang zhongle_wang@dell.com

**Change log description**

Add cahce steps in the workflow file.

**Purpose of the change**

Fixes #154 

**What the code does**

Use actions/cache@v2 and cache the build output, which will be used in the publish stage.

**How to verify it**

The artifact could be published to the JFrog artifactory on master or release branch.