### PR TITLE
Issue 158: Need to publish artifacts to Git Packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,5 +76,6 @@ jobs:
           path: ./*
           key: ${{ github.run_id }}
 
-      - name: Publish to repo
-        run: ./gradlew publishToRepo -PpublishUrl=jcenterSnapshot -PpublishUsername=$BINTRAY_USER -PpublishPassword=$BINTRAY_KEY
+      - name: Publish to Git Packages
+        run: ./gradlew publish -PpublishUrl=https://maven.pkg.github.com/${{github.repository}} -PpublishUsername=${{github.actor}} -PpublishPassword=${{secrets.GITHUB_TOKEN}}
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,5 +77,5 @@ jobs:
           key: ${{ github.run_id }}
 
       - name: Publish to Git Packages
-        run: ./gradlew publish -PpublishUrl=https://maven.pkg.github.com/${{github.repository}} -PpublishUsername=${{github.actor}} -PpublishPassword=${{secrets.GITHUB_TOKEN}}
+        run: ./gradlew publishToRepo -PpublishUrl=https://maven.pkg.github.com/${{github.repository}} -PpublishUsername=${{github.actor}} -PpublishPassword=${{secrets.GITHUB_TOKEN}}
 


### PR DESCRIPTION
**Change log description**
Changes publishing command to store artifacts on Git Packages.

**Purpose of the change**
Fixes #158.

**How to verify it**
Build should pass and artifacts should be stored in Git Packages.

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>